### PR TITLE
action+policies: only scan "current" workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Right now, it
 The conftest policies check these things:
 
 1. Every "uses" value in a job's steps needs to use a pinned ref, no tags or branches.
-2. Every job _of every workflow_ needs to depend on the init job, directly or indirectly.
+2. Every job _of the current workflow_ needs to depend on the init job, directly or indirectly.
 
 More policies may be added in the future.
 

--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,8 @@ runs:
     - name: Run Conftest
       shell: bash
       run: |
+        WORKFLOW="$(awk -F '[/@]' '{print $3"/"$4"/"$5}' <<< $WORKFLOW_REF)"
         mise use -g conftest@0.58.0
-        conftest test -o github -p "${{ github.action_path }}/policies" .github/workflows/*
+        conftest test -o github -p "${{ github.action_path }}/policies" $WORKFLOW
+      env:
+       WORKFLOW_REF: ${{ github.workflow_ref }}


### PR DESCRIPTION
This means the action is having local effects, not global effects.

It protects the current running workflow, i.e. the only including the init-action.

Fixes #16.